### PR TITLE
#1: Add project scaffolding, CLI parsing, and config loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "flywheel"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,131 @@
+use clap::Parser;
+use serde::Deserialize;
+use std::process::exit;
+
+#[derive(Debug, Clone, PartialEq)]
+enum Phase {
+    GenerateTickets,
+    SizePrioritize,
+    MoveToReady,
+    ImplementTicket,
+    CheckReady,
+}
+
+impl std::fmt::Display for Phase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Phase::GenerateTickets => write!(f, "Generate Tickets"),
+            Phase::SizePrioritize => write!(f, "Size & Prioritize"),
+            Phase::MoveToReady => write!(f, "Move to Ready"),
+            Phase::ImplementTicket => write!(f, "Implement Ticket"),
+            Phase::CheckReady => write!(f, "Check Ready"),
+        }
+    }
+}
+
+#[derive(Parser)]
+#[command(about = "Autonomous development loop using Claude Code")]
+struct Cli {
+    /// GitHub project number
+    #[arg(short, long)]
+    project: Option<u32>,
+
+    /// GitHub project owner
+    #[arg(short, long)]
+    owner: Option<String>,
+
+    /// Maximum full cycles (0 = indefinite)
+    #[arg(short = 'c', long, default_value_t = 0)]
+    max_cycles: u32,
+
+    /// Tickets to move to Ready per cycle
+    #[arg(short = 'n', long, default_value_t = 5)]
+    batch_size: u32,
+}
+
+#[derive(Deserialize, Default)]
+struct FileConfig {
+    project: Option<u32>,
+    owner: Option<String>,
+}
+
+struct Config {
+    project: u32,
+    owner: String,
+    max_cycles: u32,
+    batch_size: u32,
+}
+
+fn next_phase(current: &Phase, ready_has_items: bool) -> Phase {
+    match current {
+        Phase::GenerateTickets => Phase::SizePrioritize,
+        Phase::SizePrioritize => Phase::MoveToReady,
+        Phase::MoveToReady => Phase::ImplementTicket,
+        Phase::ImplementTicket => Phase::CheckReady,
+        Phase::CheckReady => {
+            if ready_has_items {
+                Phase::ImplementTicket
+            } else {
+                Phase::GenerateTickets
+            }
+        }
+    }
+}
+
+fn merge_config(file: FileConfig, cli: &Cli) -> Result<Config, String> {
+    let project = match cli.project.or(file.project) {
+        Some(p) => p,
+        None => return Err("Missing required field: project".to_string()),
+    };
+
+    let owner = match cli.owner.clone().or(file.owner) {
+        Some(o) => o,
+        None => return Err("Missing required field: owner".to_string()),
+    };
+
+    Ok(Config {
+        project,
+        owner,
+        max_cycles: cli.max_cycles,
+        batch_size: cli.batch_size,
+    })
+}
+
+fn load_config(cli: &Cli) -> Config {
+    let file_config = match std::fs::read_to_string(".flywheel.json") {
+        Ok(contents) => match serde_json::from_str::<FileConfig>(&contents) {
+            Ok(fc) => fc,
+            Err(e) => {
+                eprintln!("Warning: failed to parse .flywheel.json: {e}");
+                FileConfig::default()
+            }
+        },
+        Err(_) => FileConfig::default(),
+    };
+
+    match merge_config(file_config, cli) {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            eprintln!("Provide --project and --owner via CLI flags or .flywheel.json");
+            exit(1);
+        }
+    }
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let config = load_config(&cli);
+    let phase = Phase::GenerateTickets;
+    let second = next_phase(&phase, false);
+
+    println!(
+        "Flywheel configured: project={}, owner={}, max_cycles={}, batch_size={}",
+        config.project, config.owner, config.max_cycles, config.batch_size
+    );
+    println!("Starting at phase: {phase}, next: {second}");
+}
+
+#[cfg(test)]
+#[path = "main_tests.rs"]
+mod main_tests;

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+// ── merge_config: CLI flags produce correct Config ──────────────────
+
+#[test]
+fn merge_config_cli_flags_produce_correct_config() {
+    let file = FileConfig::default();
+    let cli = Cli {
+        project: Some(42),
+        owner: Some("acme".to_string()),
+        max_cycles: 3,
+        batch_size: 10,
+    };
+
+    let result = merge_config(file, &cli);
+    match result {
+        Ok(config) => {
+            assert_eq!(config.project, 42);
+            assert_eq!(config.owner, "acme");
+            assert_eq!(config.max_cycles, 3);
+            assert_eq!(config.batch_size, 10);
+        }
+        Err(e) => panic!("expected Ok, got Err: {e}"),
+    }
+}
+
+// ── merge_config: missing project errors ────────────────────────────
+
+#[test]
+fn merge_config_missing_project_returns_error() {
+    let file = FileConfig::default();
+    let cli = Cli {
+        project: None,
+        owner: Some("acme".to_string()),
+        max_cycles: 0,
+        batch_size: 5,
+    };
+
+    let result = merge_config(file, &cli);
+    match result {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(e) => assert!(e.contains("project")),
+    }
+}
+
+// ── merge_config: missing owner errors ──────────────────────────────
+
+#[test]
+fn merge_config_missing_owner_returns_error() {
+    let file = FileConfig::default();
+    let cli = Cli {
+        project: Some(1),
+        owner: None,
+        max_cycles: 0,
+        batch_size: 5,
+    };
+
+    let result = merge_config(file, &cli);
+    match result {
+        Ok(_) => panic!("expected Err, got Ok"),
+        Err(e) => assert!(e.contains("owner")),
+    }
+}
+
+// ── merge_config: file config works alone ───────────────────────────
+
+#[test]
+fn merge_config_file_config_works_alone() {
+    let file = FileConfig {
+        project: Some(99),
+        owner: Some("file-owner".to_string()),
+    };
+    let cli = Cli {
+        project: None,
+        owner: None,
+        max_cycles: 0,
+        batch_size: 5,
+    };
+
+    let result = merge_config(file, &cli);
+    match result {
+        Ok(config) => {
+            assert_eq!(config.project, 99);
+            assert_eq!(config.owner, "file-owner");
+        }
+        Err(e) => panic!("expected Ok, got Err: {e}"),
+    }
+}
+
+// ── merge_config: CLI overrides file config ─────────────────────────
+
+#[test]
+fn merge_config_cli_overrides_file_config() {
+    let file = FileConfig {
+        project: Some(10),
+        owner: Some("file-owner".to_string()),
+    };
+    let cli = Cli {
+        project: Some(20),
+        owner: Some("cli-owner".to_string()),
+        max_cycles: 7,
+        batch_size: 15,
+    };
+
+    let result = merge_config(file, &cli);
+    match result {
+        Ok(config) => {
+            assert_eq!(config.project, 20);
+            assert_eq!(config.owner, "cli-owner");
+            assert_eq!(config.max_cycles, 7);
+            assert_eq!(config.batch_size, 15);
+        }
+        Err(e) => panic!("expected Ok, got Err: {e}"),
+    }
+}
+
+// ── next_phase: all 6 transitions ───────────────────────────────────
+
+#[test]
+fn next_phase_generate_tickets_to_size_prioritize() {
+    assert_eq!(
+        next_phase(&Phase::GenerateTickets, false),
+        Phase::SizePrioritize
+    );
+}
+
+#[test]
+fn next_phase_size_prioritize_to_move_to_ready() {
+    assert_eq!(
+        next_phase(&Phase::SizePrioritize, false),
+        Phase::MoveToReady
+    );
+}
+
+#[test]
+fn next_phase_move_to_ready_to_implement_ticket() {
+    assert_eq!(
+        next_phase(&Phase::MoveToReady, false),
+        Phase::ImplementTicket
+    );
+}
+
+#[test]
+fn next_phase_implement_ticket_to_check_ready() {
+    assert_eq!(
+        next_phase(&Phase::ImplementTicket, false),
+        Phase::CheckReady
+    );
+}
+
+#[test]
+fn next_phase_check_ready_with_items_to_implement_ticket() {
+    assert_eq!(next_phase(&Phase::CheckReady, true), Phase::ImplementTicket);
+}
+
+#[test]
+fn next_phase_check_ready_without_items_to_generate_tickets() {
+    assert_eq!(
+        next_phase(&Phase::CheckReady, false),
+        Phase::GenerateTickets
+    );
+}
+
+// ── Phase Display ───────────────────────────────────────────────────
+
+#[test]
+fn phase_display_generate_tickets() {
+    assert_eq!(format!("{}", Phase::GenerateTickets), "Generate Tickets");
+}
+
+#[test]
+fn phase_display_size_prioritize() {
+    assert_eq!(format!("{}", Phase::SizePrioritize), "Size & Prioritize");
+}
+
+#[test]
+fn phase_display_move_to_ready() {
+    assert_eq!(format!("{}", Phase::MoveToReady), "Move to Ready");
+}
+
+#[test]
+fn phase_display_implement_ticket() {
+    assert_eq!(format!("{}", Phase::ImplementTicket), "Implement Ticket");
+}
+
+#[test]
+fn phase_display_check_ready() {
+    assert_eq!(format!("{}", Phase::CheckReady), "Check Ready");
+}


### PR DESCRIPTION
Resolves #1

## Summary

* Add Cargo.toml with clap, libc, serde, serde_json dependencies (edition 2024)
* Add Phase enum with Display impl for all 5 workflow phases
* Add Cli struct with clap derive for project, owner, max-cycles, batch-size args
* Add FileConfig/Config structs with .flywheel.json loading and CLI override merging
* Add next_phase() state machine transition function
* Add 16 unit tests covering config merging, phase transitions, and display

## Acceptance Criteria

- [x] `cargo run -- --help` shows usage with project, owner, max-cycles, batch-size options
- [x] `cargo run -- --project 1 --owner Zolmok` prints config confirmation and exits cleanly
- [x] Running without `--project` or `--owner` (and no `.flywheel.json`) prints an error and exits non-zero
- [x] A `.flywheel.json` with `{"project": 1, "owner": "Zolmok"}` works without CLI flags
- [x] CLI flags override `.flywheel.json` values
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt -- --check` passes