### PR TITLE
#2: Add terminal handling and subprocess spawning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,51 @@
 use clap::Parser;
 use serde::Deserialize;
-use std::process::exit;
+use std::io::{BufRead, BufReader, Read};
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio, exit};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Global PID of the active child session leader.
+/// The stdin-watcher thread reads this to kill the entire process group.
+static CHILD_PID: AtomicU32 = AtomicU32::new(0);
+
+/// Save and restore terminal settings so we can use raw mode for Ctrl-C
+/// detection while a subprocess runs.
+struct RawMode {
+    original: libc::termios,
+}
+
+impl RawMode {
+    fn enter() -> Option<Self> {
+        unsafe {
+            let mut original: libc::termios = std::mem::zeroed();
+            if libc::tcgetattr(0, &mut original) != 0 {
+                return None;
+            }
+            let mut raw = original;
+            raw.c_lflag &= !(libc::ICANON | libc::ECHO | libc::ISIG);
+            raw.c_cc[libc::VMIN] = 1;
+            raw.c_cc[libc::VTIME] = 0;
+            if libc::tcsetattr(0, libc::TCSANOW, &raw) != 0 {
+                return None;
+            }
+            Some(RawMode { original })
+        }
+    }
+
+    fn restore(&self) {
+        unsafe {
+            libc::tcsetattr(0, libc::TCSANOW, &self.original);
+        }
+    }
+}
+
+impl Drop for RawMode {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 enum Phase {
@@ -113,9 +158,177 @@ fn load_config(cli: &Cli) -> Config {
     }
 }
 
+fn spawn_and_capture(label: &str, program: &str, args: &[&str]) -> Option<String> {
+    let mut cmd = Command::new(program);
+    cmd.args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // New session so the child cannot open /dev/tty or affect our terminal
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Failed to spawn {program}: {e}");
+            return None;
+        }
+    };
+
+    // Store child PID so the stdin-watcher can kill the process group
+    CHILD_PID.store(child.id(), Ordering::Relaxed);
+
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => {
+            eprintln!("{label}: no stdout pipe");
+            return None;
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(s) => s,
+        None => {
+            eprintln!("{label}: no stderr pipe");
+            return None;
+        }
+    };
+
+    let output = Arc::new(Mutex::new(String::new()));
+
+    // Spawn a thread to stream stderr to terminal AND capture it
+    let output_clone = output.clone();
+    let stderr_handle = std::thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => {
+                    eprintln!("{line}");
+                    match output_clone.lock() {
+                        Ok(mut out) => {
+                            out.push_str(&line);
+                            out.push('\n');
+                        }
+                        Err(e) => {
+                            eprintln!("stderr lock poisoned: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("stderr read error: {e}");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Stream stdout to terminal AND capture it
+    let output_clone2 = output.clone();
+    let reader = BufReader::new(stdout);
+    for line in reader.lines() {
+        match line {
+            Ok(line) => {
+                println!("{line}");
+                match output_clone2.lock() {
+                    Ok(mut out) => {
+                        out.push_str(&line);
+                        out.push('\n');
+                    }
+                    Err(e) => {
+                        eprintln!("{label}: stdout lock poisoned: {e}");
+                    }
+                }
+            }
+            Err(e) => {
+                eprintln!("{label}: stdout read error: {e}");
+                break;
+            }
+        }
+    }
+
+    drop(output_clone2);
+    let _ = stderr_handle.join();
+
+    let status = child.wait();
+    CHILD_PID.store(0, Ordering::Relaxed);
+
+    let output = match Arc::try_unwrap(output) {
+        Ok(mutex) => match mutex.into_inner() {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("{label}: mutex poisoned: {e}");
+                e.into_inner()
+            }
+        },
+        Err(arc) => {
+            eprintln!("{label}: Arc still has multiple owners, cloning");
+            match arc.lock() {
+                Ok(s) => s.clone(),
+                Err(e) => {
+                    eprintln!("{label}: fallback lock poisoned: {e}");
+                    e.into_inner().clone()
+                }
+            }
+        }
+    };
+
+    match status {
+        Ok(s) => {
+            if !s.success() {
+                eprintln!("{label}: {program} exited with {s}");
+            }
+            Some(output)
+        }
+        Err(e) => {
+            eprintln!("{label}: failed to wait on {program}: {e}");
+            None
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
     let config = load_config(&cli);
+
+    let _raw_mode = RawMode::enter();
+
+    // Spawn a stdin-watcher thread that reads for Ctrl-C bytes.
+    // When detected, kill the child process group and exit.
+    std::thread::spawn(move || {
+        let stdin = std::io::stdin();
+        let mut buf = [0u8; 1];
+        loop {
+            match stdin.lock().read(&mut buf) {
+                Ok(0) => break,
+                Ok(_) => {
+                    if buf[0] == 0x03 {
+                        let pid = CHILD_PID.load(Ordering::Relaxed);
+                        if pid != 0 {
+                            unsafe {
+                                libc::kill(-(pid as i32), libc::SIGKILL);
+                            }
+                        }
+                        eprintln!("\n=== Interrupted ===");
+                        // Restore terminal before exiting
+                        unsafe {
+                            let mut original: libc::termios = std::mem::zeroed();
+                            libc::tcgetattr(0, &mut original);
+                            original.c_lflag |= libc::ICANON | libc::ECHO | libc::ISIG;
+                            libc::tcsetattr(0, libc::TCSANOW, &original);
+                        }
+                        std::process::exit(1);
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
     let phase = Phase::GenerateTickets;
     let second = next_phase(&phase, false);
 

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -187,3 +187,44 @@ fn phase_display_implement_ticket() {
 fn phase_display_check_ready() {
     assert_eq!(format!("{}", Phase::CheckReady), "Check Ready");
 }
+
+// ── spawn_and_capture ────────────────────────────────────────────────
+
+#[test]
+fn spawn_and_capture_echo_returns_output() {
+    let result = spawn_and_capture("test", "echo", &["hello"]);
+    match result {
+        Some(output) => assert_eq!(output, "hello\n"),
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn spawn_and_capture_nonexistent_program_returns_none() {
+    let result = spawn_and_capture("test", "nonexistent_program_xyz", &[]);
+    assert!(result.is_none(), "expected None, got Some");
+}
+
+#[test]
+fn spawn_and_capture_captures_multiline_output() {
+    let result = spawn_and_capture("test", "printf", &["line1\nline2\nline3\n"]);
+    match result {
+        Some(output) => {
+            assert!(output.contains("line1"));
+            assert!(output.contains("line2"));
+            assert!(output.contains("line3"));
+        }
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn spawn_and_capture_failed_exit_still_returns_output() {
+    let result = spawn_and_capture("test", "sh", &["-c", "echo output && exit 1"]);
+    match result {
+        Some(output) => {
+            assert!(output.contains("output"));
+        }
+        None => panic!("expected Some, got None"),
+    }
+}


### PR DESCRIPTION
Resolves #2

## Summary

* Add `CHILD_PID` static for tracking the active child process PID
* Add `RawMode` struct for raw terminal mode management (enter/restore/Drop)
* Add `spawn_and_capture(label, program, args)` that spawns any subprocess, streams stdout/stderr to the terminal in real-time while capturing output, and returns `Option<String>`
* Add stdin-watcher thread for Ctrl-C detection that kills the child process group and restores terminal settings
* Add 4 unit tests for `spawn_and_capture`

## Acceptance Criteria

- [x] `spawn_and_capture("test", "echo", &["hello"])` returns `Some("hello\n")`
- [x] Subprocess stdout and stderr stream to the terminal in real-time
- [x] Ctrl-C during a subprocess kills the child and exits cleanly
- [x] Terminal settings are restored after normal exit and after Ctrl-C
- [x] `cargo clippy` passes with no warnings (except expected dead_code for `spawn_and_capture` which is wired in ticket #3)
- [x] `cargo fmt -- --check` passes