### PR TITLE
#4: Wire main loop state machine with phase dispatch

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -424,6 +424,13 @@ fn spawn_and_capture(label: &str, program: &str, args: &[&str]) -> Option<String
     }
 }
 
+fn print_phase_banner(phase: &Phase, cycle: u32) {
+    println!("=========================================");
+    println!("  Flywheel \u{2014} cycle {cycle}");
+    println!("  Phase: {phase}");
+    println!("=========================================");
+}
+
 fn main() {
     let cli = Cli::parse();
     let config = load_config(&cli);
@@ -462,14 +469,37 @@ fn main() {
         }
     });
 
-    let phase = Phase::GenerateTickets;
-    let second = next_phase(&phase, false);
+    let mut phase = Phase::GenerateTickets;
+    let mut cycle: u32 = 1;
 
-    println!(
-        "Flywheel configured: project={}, owner={}, max_cycles={}, batch_size={}",
-        config.project, config.owner, config.max_cycles, config.batch_size
-    );
-    println!("Starting at phase: {phase}, next: {second}");
+    loop {
+        print_phase_banner(&phase, cycle);
+
+        match run_phase(&phase, &config) {
+            None => {
+                eprintln!("=== Phase \"{}\" failed, stopping ===", phase);
+                break;
+            }
+            Some(next) => {
+                println!("--- {} complete, moving to {} ---", phase, next);
+
+                if phase == Phase::CheckReady && next == Phase::GenerateTickets {
+                    println!(
+                        "=== Cycle {} complete, starting cycle {} ===",
+                        cycle,
+                        cycle + 1
+                    );
+                    cycle += 1;
+                    if config.max_cycles > 0 && cycle > config.max_cycles {
+                        println!("=== Reached max cycles ({}) ===", config.max_cycles);
+                        break;
+                    }
+                }
+
+                phase = next;
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves #4

## Summary

* Add `print_phase_banner()` function that displays cycle number and phase name in a formatted banner
* Replace the `main()` stub with a full state machine loop that dispatches phases via `run_phase()`
* Print transition messages between phases (`--- X complete, moving to Y ---`)
* Detect cycle boundaries when CheckReady transitions to GenerateTickets and increment the cycle counter
* Enforce `max_cycles` limit — stops with `=== Reached max cycles (N) ===` when exceeded
* Print failure message and break on any phase error (`=== Phase "X" failed, stopping ===`)
* Terminal restored on all exit paths via `_raw_mode` Drop

## Acceptance Criteria

- [x] Phase banners display with correct cycle number and phase name
- [x] Transition messages appear between phases
- [x] Cycle boundary is detected (CheckReady → GenerateTickets) and cycle count increments
- [x] `--max-cycles 1` stops after one full cycle
- [x] `--max-cycles 0` runs indefinitely (until error or Ctrl-C)
- [x] Phase failure prints error message and exits
- [x] Terminal is restored on all exit paths (normal, error, Ctrl-C)
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt -- --check` passes