### PR TITLE
#12: Load .envrc via direnv before spawning subprocesses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio, exit};
@@ -158,6 +159,63 @@ fn load_config(cli: &Cli) -> Config {
     }
 }
 
+fn load_direnv_env() -> HashMap<String, String> {
+    let output = match Command::new("direnv")
+        .args(["export", "json"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("direnv not available: {e}");
+            return HashMap::new();
+        }
+    };
+
+    let stdout = match String::from_utf8(output.stdout) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("direnv output not valid UTF-8: {e}");
+            return HashMap::new();
+        }
+    };
+
+    if stdout.trim().is_empty() {
+        return HashMap::new();
+    }
+
+    let parsed: serde_json::Value = match serde_json::from_str(&stdout) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Failed to parse direnv JSON: {e}");
+            return HashMap::new();
+        }
+    };
+
+    let obj = match parsed.as_object() {
+        Some(o) => o,
+        None => {
+            eprintln!("direnv output is not a JSON object");
+            return HashMap::new();
+        }
+    };
+
+    let mut env = HashMap::new();
+    for (key, value) in obj {
+        match value.as_str() {
+            Some(v) => {
+                env.insert(key.clone(), v.to_string());
+            }
+            None => {
+                // null or non-string values are skipped (direnv uses null for unset)
+            }
+        }
+    }
+    env
+}
+
 fn build_generate_tickets_prompt(config: &Config) -> String {
     format!(
         "Use the Skill tool to invoke 'generate-tickets' with arguments \
@@ -246,7 +304,7 @@ fn parse_ready_items(json: &str) -> bool {
     }
 }
 
-fn check_ready_column(config: &Config) -> bool {
+fn check_ready_column(config: &Config, extra_env: &HashMap<String, String>) -> bool {
     let project_str = config.project.to_string();
     let output = spawn_and_capture(
         "check-ready",
@@ -260,6 +318,7 @@ fn check_ready_column(config: &Config) -> bool {
             "--format",
             "json",
         ],
+        extra_env,
     );
     match output {
         Some(json) => parse_ready_items(&json),
@@ -267,10 +326,10 @@ fn check_ready_column(config: &Config) -> bool {
     }
 }
 
-fn run_phase(phase: &Phase, config: &Config) -> Option<Phase> {
+fn run_phase(phase: &Phase, config: &Config, extra_env: &HashMap<String, String>) -> Option<Phase> {
     match phase {
         Phase::CheckReady => {
-            let has_items = check_ready_column(config);
+            let has_items = check_ready_column(config, extra_env);
             Some(next_phase(phase, has_items))
         }
         _ => {
@@ -285,15 +344,22 @@ fn run_phase(phase: &Phase, config: &Config) -> Option<Phase> {
                 &format!("{phase}"),
                 "claude",
                 &["-p", &prompt, "--dangerously-skip-permissions"],
+                extra_env,
             );
             result.map(|_| next_phase(phase, false))
         }
     }
 }
 
-fn spawn_and_capture(label: &str, program: &str, args: &[&str]) -> Option<String> {
+fn spawn_and_capture(
+    label: &str,
+    program: &str,
+    args: &[&str],
+    extra_env: &HashMap<String, String>,
+) -> Option<String> {
     let mut cmd = Command::new(program);
     cmd.args(args)
+        .envs(extra_env)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -434,6 +500,7 @@ fn print_phase_banner(phase: &Phase, cycle: u32) {
 fn main() {
     let cli = Cli::parse();
     let config = load_config(&cli);
+    let direnv_env = load_direnv_env();
 
     let _raw_mode = RawMode::enter();
 
@@ -475,7 +542,7 @@ fn main() {
     loop {
         print_phase_banner(&phase, cycle);
 
-        match run_phase(&phase, &config) {
+        match run_phase(&phase, &config, &direnv_env) {
             None => {
                 eprintln!("=== Phase \"{}\" failed, stopping ===", phase);
                 break;

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashMap;
 
 // ── merge_config: CLI flags produce correct Config ──────────────────
 
@@ -192,7 +193,7 @@ fn phase_display_check_ready() {
 
 #[test]
 fn spawn_and_capture_echo_returns_output() {
-    let result = spawn_and_capture("test", "echo", &["hello"]);
+    let result = spawn_and_capture("test", "echo", &["hello"], &HashMap::new());
     match result {
         Some(output) => assert_eq!(output, "hello\n"),
         None => panic!("expected Some, got None"),
@@ -201,13 +202,18 @@ fn spawn_and_capture_echo_returns_output() {
 
 #[test]
 fn spawn_and_capture_nonexistent_program_returns_none() {
-    let result = spawn_and_capture("test", "nonexistent_program_xyz", &[]);
+    let result = spawn_and_capture("test", "nonexistent_program_xyz", &[], &HashMap::new());
     assert!(result.is_none(), "expected None, got Some");
 }
 
 #[test]
 fn spawn_and_capture_captures_multiline_output() {
-    let result = spawn_and_capture("test", "printf", &["line1\nline2\nline3\n"]);
+    let result = spawn_and_capture(
+        "test",
+        "printf",
+        &["line1\nline2\nline3\n"],
+        &HashMap::new(),
+    );
     match result {
         Some(output) => {
             assert!(output.contains("line1"));
@@ -220,7 +226,12 @@ fn spawn_and_capture_captures_multiline_output() {
 
 #[test]
 fn spawn_and_capture_failed_exit_still_returns_output() {
-    let result = spawn_and_capture("test", "sh", &["-c", "echo output && exit 1"]);
+    let result = spawn_and_capture(
+        "test",
+        "sh",
+        &["-c", "echo output && exit 1"],
+        &HashMap::new(),
+    );
     match result {
         Some(output) => {
             assert!(output.contains("output"));
@@ -445,9 +456,50 @@ fn run_phase_check_ready_returns_some_phase() {
         max_cycles: 0,
         batch_size: 5,
     };
-    let result = run_phase(&Phase::CheckReady, &config);
+    let result = run_phase(&Phase::CheckReady, &config, &HashMap::new());
     match result {
         Some(phase) => assert_eq!(phase, Phase::GenerateTickets),
+        None => panic!("expected Some, got None"),
+    }
+}
+
+// ── load_direnv_env ─────────────────────────────────────────────────
+
+#[test]
+fn load_direnv_env_returns_hashmap() {
+    // In test environments direnv may or may not be installed, and there
+    // may or may not be a .envrc. Either way the function must return a
+    // HashMap without panicking.
+    let env = load_direnv_env();
+    // We can only assert the type is correct (HashMap) and it didn't panic.
+    // If direnv is not installed, the map will be empty.
+    let _ = env.len();
+}
+
+// ── spawn_and_capture: extra_env propagation ────────────────────────
+
+#[test]
+fn spawn_and_capture_propagates_extra_env() {
+    let mut env = HashMap::new();
+    env.insert(
+        "FLYWHEEL_TEST_VAR".to_string(),
+        "hello_from_direnv".to_string(),
+    );
+    let result = spawn_and_capture("test", "sh", &["-c", "echo $FLYWHEEL_TEST_VAR"], &env);
+    match result {
+        Some(output) => assert!(
+            output.contains("hello_from_direnv"),
+            "expected env var in output, got: {output}"
+        ),
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn spawn_and_capture_empty_extra_env_works() {
+    let result = spawn_and_capture("test", "echo", &["ok"], &HashMap::new());
+    match result {
+        Some(output) => assert!(output.contains("ok")),
         None => panic!("expected Some, got None"),
     }
 }


### PR DESCRIPTION
Resolves #12

## Summary

* Add `load_direnv_env()` that runs `direnv export json` at startup and parses the resulting JSON into a `HashMap<String, String>` of environment overrides
* Thread the extra env through `run_phase()` → `check_ready_column()` / `spawn_and_capture()` so all spawned subprocesses (`claude`, `gh`) inherit direnv variables
* Gracefully handle missing direnv, missing `.envrc`, and malformed JSON by returning an empty map (no panic, no exit)
* Add tests for env propagation and resilience

## Acceptance Criteria

- [x] `load_direnv_env()` returns a populated `HashMap` when `.envrc` exists and direnv is installed
- [x] `load_direnv_env()` returns an empty `HashMap` when direnv is not installed (no panic/exit)
- [x] `load_direnv_env()` returns an empty `HashMap` when no `.envrc` exists (no panic/exit)
- [x] Spawned subprocesses (`claude`, `gh`) receive the environment variables from `.envrc`
- [x] Flywheel works identically to before when no `.envrc` is present
- [x] `cargo test` passes with all tests green
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt -- --check` passes