### PR TITLE
#12: Fix OAuth auth for spawned claude subprocesses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,39 @@ fn load_direnv_env() -> HashMap<String, String> {
     env
 }
 
+fn resolve_claude_profile(env: &mut HashMap<String, String>) {
+    let profile = match env.get("CLAUDE_PROFILE") {
+        Some(p) => p.clone(),
+        None => match std::env::var("CLAUDE_PROFILE") {
+            Ok(p) => p,
+            Err(_) => return,
+        },
+    };
+
+    let home = match std::env::var("HOME") {
+        Ok(h) => h,
+        Err(_) => return,
+    };
+
+    let profile_dir = format!("{home}/.claude/profiles/{profile}");
+    let profile_path = std::path::Path::new(&profile_dir);
+    if !profile_path.is_dir() {
+        eprintln!("Claude profile directory not found: {profile_dir}");
+        return;
+    }
+
+    let src = format!("{profile_dir}/claude.json");
+    let dst = format!("{home}/.claude.json");
+    match std::fs::copy(&src, &dst) {
+        Ok(_) => {}
+        Err(e) => {
+            eprintln!("Failed to copy {src} to {dst}: {e}");
+        }
+    }
+
+    env.insert("CLAUDE_CONFIG_DIR".to_string(), profile_dir);
+}
+
 fn build_generate_tickets_prompt(config: &Config) -> String {
     format!(
         "Use the Skill tool to invoke 'generate-tickets' with arguments \
@@ -502,7 +535,8 @@ fn print_phase_banner(phase: &Phase, cycle: u32) {
 fn main() {
     let cli = Cli::parse();
     let config = load_config(&cli);
-    let direnv_env = load_direnv_env();
+    let mut direnv_env = load_direnv_env();
+    resolve_claude_profile(&mut direnv_env);
 
     let _raw_mode = RawMode::enter();
 


### PR DESCRIPTION
Resolves #12

## Summary

* Replace `setsid()` with `setpgid(0, 0)` in `spawn_and_capture()` so child processes stay in the same session and can access `/dev/tty` for OAuth token refresh
* Add `resolve_claude_profile()` that replicates the shell function wrapper: copies the profile's `claude.json` to `~/.claude.json` and sets `CLAUDE_CONFIG_DIR` in the subprocess env
* Root cause: flywheel spawns the `claude` binary directly, bypassing the user's shell function that sets up profile-specific auth config — causing claude to use the wrong/expired OAuth token

## Acceptance Criteria

- [x] Spawned subprocesses (`claude`, `gh`) receive the correct environment and auth config
- [x] Flywheel works identically to before when no `CLAUDE_PROFILE` is set
- [x] `cargo test` passes with all tests green
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt -- --check` passes