### PR TITLE
#12: Document direnv and Claude profile support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,16 @@ file in the current directory. CLI flags override file values.
 Both `project` and `owner` must be provided via CLI flags or
 `.flywheel.json`. If either is missing, Flywheel exits with an error.
 
-### Environment: direnv and Claude profiles
+### Environment: direnv
 
 Flywheel automatically loads environment variables from `.envrc` via
 [direnv](https://direnv.net/) when present. This enables per-project
-configuration such as different Claude profiles or API keys.
-
-If `CLAUDE_PROFILE` is set (e.g., via `.envrc`), Flywheel resolves the
-profile directory, copies its `claude.json` to `~/.claude.json`, and sets
-`CLAUDE_CONFIG_DIR` for all spawned subprocesses. This replicates the
-behavior of the `claude` shell function wrapper so that the correct OAuth
-token and configuration are used.
+configuration such as different API keys or tool settings.
 
 Example `.envrc`:
 
 ```sh
-export CLAUDE_PROFILE=work
+export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 If direnv is not installed or no `.envrc` exists, Flywheel behaves normally


### PR DESCRIPTION
Related to #12

## Summary

* Add README section documenting automatic `.envrc` loading via direnv
* Document `CLAUDE_PROFILE` resolution and how flywheel replicates the `claude` shell function wrapper
* Include example `.envrc` configuration