### PR TITLE
#17: Skip GenerateTickets when backlog has 5+ items

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,28 @@ fn build_implement_ticket_prompt(config: &Config) -> String {
     )
 }
 
+fn count_backlog_items(json: &str) -> usize {
+    match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(value) => match value.get("items") {
+            Some(items) => match items.as_array() {
+                Some(arr) => arr
+                    .iter()
+                    .filter(|item| match item.get("status") {
+                        Some(status) => match status.as_str() {
+                            Some(s) => s == "Backlog",
+                            None => false,
+                        },
+                        None => false,
+                    })
+                    .count(),
+                None => 0,
+            },
+            None => 0,
+        },
+        Err(_) => 0,
+    }
+}
+
 fn parse_ready_items(json: &str) -> bool {
     match serde_json::from_str::<serde_json::Value>(json) {
         Ok(value) => match value.get("items") {
@@ -334,6 +356,28 @@ fn parse_ready_items(json: &str) -> bool {
             None => false,
         },
         Err(_) => false,
+    }
+}
+
+fn check_backlog_count(config: &Config, extra_env: &HashMap<String, String>) -> usize {
+    let project_str = config.project.to_string();
+    let output = spawn_and_capture(
+        "check-backlog",
+        "gh",
+        &[
+            "project",
+            "item-list",
+            &project_str,
+            "--owner",
+            &config.owner,
+            "--format",
+            "json",
+        ],
+        extra_env,
+    );
+    match output {
+        Some(json) => count_backlog_items(&json),
+        None => 0,
     }
 }
 
@@ -365,13 +409,27 @@ fn run_phase(phase: &Phase, config: &Config, extra_env: &HashMap<String, String>
             let has_items = check_ready_column(config, extra_env);
             Some(next_phase(phase, has_items))
         }
+        Phase::GenerateTickets => {
+            let backlog_count = check_backlog_count(config, extra_env);
+            if backlog_count >= 5 {
+                println!("Backlog has {backlog_count} items, skipping ticket generation");
+                return Some(Phase::SizePrioritize);
+            }
+            let prompt = build_generate_tickets_prompt(config);
+            let result = spawn_and_capture(
+                &format!("{phase}"),
+                "claude",
+                &["-p", &prompt, "--dangerously-skip-permissions"],
+                extra_env,
+            );
+            result.map(|_| next_phase(phase, false))
+        }
         _ => {
             let prompt = match phase {
-                Phase::GenerateTickets => build_generate_tickets_prompt(config),
                 Phase::SizePrioritize => build_size_prioritize_prompt(config),
                 Phase::MoveToReady => build_move_to_ready_prompt(config),
                 Phase::ImplementTicket => build_implement_ticket_prompt(config),
-                Phase::CheckReady => unreachable!(),
+                Phase::CheckReady | Phase::GenerateTickets => unreachable!(),
             };
             let result = spawn_and_capture(
                 &format!("{phase}"),

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -503,3 +503,53 @@ fn spawn_and_capture_empty_extra_env_works() {
         None => panic!("expected Some, got None"),
     }
 }
+
+// ── count_backlog_items ──────────────────────────────────────────
+
+#[test]
+fn count_backlog_items_mixed_statuses_counts_only_backlog() {
+    let json = r#"{"items":[
+        {"status":"Backlog","title":"A"},
+        {"status":"Ready","title":"B"},
+        {"status":"Done","title":"C"},
+        {"status":"Backlog","title":"D"},
+        {"status":"Ready","title":"E"}
+    ],"totalCount":5}"#;
+    assert_eq!(count_backlog_items(json), 2);
+}
+
+#[test]
+fn count_backlog_items_empty_items_returns_zero() {
+    let json = r#"{"items":[],"totalCount":0}"#;
+    assert_eq!(count_backlog_items(json), 0);
+}
+
+#[test]
+fn count_backlog_items_malformed_json_returns_zero() {
+    let json = "not valid json at all";
+    assert_eq!(count_backlog_items(json), 0);
+}
+
+#[test]
+fn count_backlog_items_exactly_five_backlog_items() {
+    let json = r#"{"items":[
+        {"status":"Backlog","title":"A"},
+        {"status":"Backlog","title":"B"},
+        {"status":"Backlog","title":"C"},
+        {"status":"Backlog","title":"D"},
+        {"status":"Backlog","title":"E"}
+    ],"totalCount":5}"#;
+    assert_eq!(count_backlog_items(json), 5);
+}
+
+#[test]
+fn count_backlog_items_four_backlog_items_below_threshold() {
+    let json = r#"{"items":[
+        {"status":"Backlog","title":"A"},
+        {"status":"Backlog","title":"B"},
+        {"status":"Backlog","title":"C"},
+        {"status":"Backlog","title":"D"},
+        {"status":"Ready","title":"E"}
+    ],"totalCount":5}"#;
+    assert_eq!(count_backlog_items(json), 4);
+}


### PR DESCRIPTION
Resolves #17

## Summary

* Add `count_backlog_items()` and `check_backlog_count()` functions to query the project board and count Backlog items
* Modify `run_phase` to check the backlog count before executing `GenerateTickets` — if >= 5, skip directly to `SizePrioritize`
* Print a log message when skipping (e.g., "Backlog has 7 items, skipping ticket generation")
* Add 5 unit tests for `count_backlog_items` covering mixed statuses, empty list, malformed JSON, and threshold boundaries

## Acceptance Criteria

- [x] When Backlog has >= 5 items, `GenerateTickets` is skipped and cycle proceeds to `SizePrioritize`
- [x] When Backlog has < 5 items, `GenerateTickets` runs as normal
- [x] A log message is printed when skipping (e.g., "Backlog has 7 items, skipping ticket generation")
- [x] `count_backlog_items` has unit tests covering: mixed statuses, empty list, malformed JSON, exactly 5 items, exactly 4 items
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)