### PR TITLE
#18: Suppress noisy JSON output during CheckReady phase

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -340,22 +340,25 @@ fn count_backlog_items(json: &str) -> usize {
     }
 }
 
-fn parse_ready_items(json: &str) -> bool {
+fn count_ready_items(json: &str) -> usize {
     match serde_json::from_str::<serde_json::Value>(json) {
         Ok(value) => match value.get("items") {
             Some(items) => match items.as_array() {
-                Some(arr) => arr.iter().any(|item| match item.get("status") {
-                    Some(status) => match status.as_str() {
-                        Some(s) => s == "Ready",
+                Some(arr) => arr
+                    .iter()
+                    .filter(|item| match item.get("status") {
+                        Some(status) => match status.as_str() {
+                            Some(s) => s == "Ready",
+                            None => false,
+                        },
                         None => false,
-                    },
-                    None => false,
-                }),
-                None => false,
+                    })
+                    .count(),
+                None => 0,
             },
-            None => false,
+            None => 0,
         },
-        Err(_) => false,
+        Err(_) => 0,
     }
 }
 
@@ -374,6 +377,7 @@ fn check_backlog_count(config: &Config, extra_env: &HashMap<String, String>) -> 
             "json",
         ],
         extra_env,
+        true,
     );
     match output {
         Some(json) => count_backlog_items(&json),
@@ -381,7 +385,7 @@ fn check_backlog_count(config: &Config, extra_env: &HashMap<String, String>) -> 
     }
 }
 
-fn check_ready_column(config: &Config, extra_env: &HashMap<String, String>) -> bool {
+fn check_ready_column(config: &Config, extra_env: &HashMap<String, String>) -> (bool, usize) {
     let project_str = config.project.to_string();
     let output = spawn_and_capture(
         "check-ready",
@@ -396,17 +400,26 @@ fn check_ready_column(config: &Config, extra_env: &HashMap<String, String>) -> b
             "json",
         ],
         extra_env,
+        true,
     );
     match output {
-        Some(json) => parse_ready_items(&json),
-        None => false,
+        Some(json) => {
+            let count = count_ready_items(&json);
+            (count > 0, count)
+        }
+        None => (false, 0),
     }
 }
 
 fn run_phase(phase: &Phase, config: &Config, extra_env: &HashMap<String, String>) -> Option<Phase> {
     match phase {
         Phase::CheckReady => {
-            let has_items = check_ready_column(config, extra_env);
+            let (has_items, count) = check_ready_column(config, extra_env);
+            if count == 0 {
+                println!("Ready column: empty");
+            } else {
+                println!("Ready column: {count} item(s)");
+            }
             Some(next_phase(phase, has_items))
         }
         Phase::GenerateTickets => {
@@ -421,6 +434,7 @@ fn run_phase(phase: &Phase, config: &Config, extra_env: &HashMap<String, String>
                 "claude",
                 &["-p", &prompt, "--dangerously-skip-permissions"],
                 extra_env,
+                false,
             );
             result.map(|_| next_phase(phase, false))
         }
@@ -436,6 +450,7 @@ fn run_phase(phase: &Phase, config: &Config, extra_env: &HashMap<String, String>
                 "claude",
                 &["-p", &prompt, "--dangerously-skip-permissions"],
                 extra_env,
+                false,
             );
             result.map(|_| next_phase(phase, false))
         }
@@ -447,6 +462,7 @@ fn spawn_and_capture(
     program: &str,
     args: &[&str],
     extra_env: &HashMap<String, String>,
+    quiet: bool,
 ) -> Option<String> {
     let mut cmd = Command::new(program);
     cmd.args(args)
@@ -500,7 +516,9 @@ fn spawn_and_capture(
         for line in reader.lines() {
             match line {
                 Ok(line) => {
-                    eprintln!("{line}");
+                    if !quiet {
+                        eprintln!("{line}");
+                    }
                     match output_clone.lock() {
                         Ok(mut out) => {
                             out.push_str(&line);
@@ -525,7 +543,9 @@ fn spawn_and_capture(
     for line in reader.lines() {
         match line {
             Ok(line) => {
-                println!("{line}");
+                if !quiet {
+                    println!("{line}");
+                }
                 match output_clone2.lock() {
                     Ok(mut out) => {
                         out.push_str(&line);

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -193,7 +193,7 @@ fn phase_display_check_ready() {
 
 #[test]
 fn spawn_and_capture_echo_returns_output() {
-    let result = spawn_and_capture("test", "echo", &["hello"], &HashMap::new());
+    let result = spawn_and_capture("test", "echo", &["hello"], &HashMap::new(), false);
     match result {
         Some(output) => assert_eq!(output, "hello\n"),
         None => panic!("expected Some, got None"),
@@ -202,7 +202,13 @@ fn spawn_and_capture_echo_returns_output() {
 
 #[test]
 fn spawn_and_capture_nonexistent_program_returns_none() {
-    let result = spawn_and_capture("test", "nonexistent_program_xyz", &[], &HashMap::new());
+    let result = spawn_and_capture(
+        "test",
+        "nonexistent_program_xyz",
+        &[],
+        &HashMap::new(),
+        false,
+    );
     assert!(result.is_none(), "expected None, got Some");
 }
 
@@ -213,6 +219,7 @@ fn spawn_and_capture_captures_multiline_output() {
         "printf",
         &["line1\nline2\nline3\n"],
         &HashMap::new(),
+        false,
     );
     match result {
         Some(output) => {
@@ -231,6 +238,7 @@ fn spawn_and_capture_failed_exit_still_returns_output() {
         "sh",
         &["-c", "echo output && exit 1"],
         &HashMap::new(),
+        false,
     );
     match result {
         Some(output) => {
@@ -398,48 +406,59 @@ fn build_implement_ticket_prompt_contains_implement_ticket_skill() {
     );
 }
 
-// ── parse_ready_items ───────────────────────────────────────────────
+// ── count_ready_items ───────────────────────────────────────────────
 
 #[test]
-fn parse_ready_items_returns_true_when_ready_item_exists() {
+fn count_ready_items_returns_one_when_ready_item_exists() {
     let json = r#"{"items":[{"status":"Ready","title":"Do something"}],"totalCount":1}"#;
-    assert!(parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 1);
 }
 
 #[test]
-fn parse_ready_items_returns_true_with_mixed_statuses() {
+fn count_ready_items_with_mixed_statuses() {
     let json = r#"{"items":[{"status":"Backlog","title":"A"},{"status":"Ready","title":"B"}],"totalCount":2}"#;
-    assert!(parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 1);
 }
 
 #[test]
-fn parse_ready_items_returns_false_for_empty_items() {
+fn count_ready_items_returns_zero_for_empty_items() {
     let json = r#"{"items":[],"totalCount":0}"#;
-    assert!(!parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 0);
 }
 
 #[test]
-fn parse_ready_items_returns_false_when_all_backlog() {
+fn count_ready_items_returns_zero_when_all_backlog() {
     let json = r#"{"items":[{"status":"Backlog","title":"A"},{"status":"Backlog","title":"B"}],"totalCount":2}"#;
-    assert!(!parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 0);
 }
 
 #[test]
-fn parse_ready_items_returns_false_for_malformed_json() {
+fn count_ready_items_returns_zero_for_malformed_json() {
     let json = "not valid json at all";
-    assert!(!parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 0);
 }
 
 #[test]
-fn parse_ready_items_returns_false_when_items_key_missing() {
+fn count_ready_items_returns_zero_when_items_key_missing() {
     let json = r#"{"totalCount":0}"#;
-    assert!(!parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 0);
 }
 
 #[test]
-fn parse_ready_items_returns_false_when_status_key_missing() {
+fn count_ready_items_returns_zero_when_status_key_missing() {
     let json = r#"{"items":[{"title":"No status field"}],"totalCount":1}"#;
-    assert!(!parse_ready_items(json));
+    assert_eq!(count_ready_items(json), 0);
+}
+
+#[test]
+fn count_ready_items_multiple_ready_items() {
+    let json = r#"{"items":[
+        {"status":"Ready","title":"A"},
+        {"status":"Backlog","title":"B"},
+        {"status":"Ready","title":"C"},
+        {"status":"Done","title":"D"}
+    ],"totalCount":4}"#;
+    assert_eq!(count_ready_items(json), 2);
 }
 
 // ── run_phase: CheckReady variant ───────────────────────────────────
@@ -485,7 +504,13 @@ fn spawn_and_capture_propagates_extra_env() {
         "FLYWHEEL_TEST_VAR".to_string(),
         "hello_from_direnv".to_string(),
     );
-    let result = spawn_and_capture("test", "sh", &["-c", "echo $FLYWHEEL_TEST_VAR"], &env);
+    let result = spawn_and_capture(
+        "test",
+        "sh",
+        &["-c", "echo $FLYWHEEL_TEST_VAR"],
+        &env,
+        false,
+    );
     match result {
         Some(output) => assert!(
             output.contains("hello_from_direnv"),
@@ -497,7 +522,7 @@ fn spawn_and_capture_propagates_extra_env() {
 
 #[test]
 fn spawn_and_capture_empty_extra_env_works() {
-    let result = spawn_and_capture("test", "echo", &["ok"], &HashMap::new());
+    let result = spawn_and_capture("test", "echo", &["ok"], &HashMap::new(), false);
     match result {
         Some(output) => assert!(output.contains("ok")),
         None => panic!("expected Some, got None"),
@@ -552,4 +577,18 @@ fn count_backlog_items_four_backlog_items_below_threshold() {
         {"status":"Ready","title":"E"}
     ],"totalCount":5}"#;
     assert_eq!(count_backlog_items(json), 4);
+}
+
+// ── spawn_and_capture: quiet mode ──────────────────────────────────
+
+#[test]
+fn spawn_and_capture_quiet_still_captures_output() {
+    let result = spawn_and_capture("test", "echo", &["captured"], &HashMap::new(), true);
+    match result {
+        Some(output) => assert!(
+            output.contains("captured"),
+            "quiet mode should still capture output, got: {output}"
+        ),
+        None => panic!("expected Some, got None"),
+    }
 }


### PR DESCRIPTION
Resolves #18

## Summary

* Add `quiet: bool` parameter to `spawn_and_capture` that suppresses `println!`/`eprintln!` while still capturing output
* Use quiet mode for `check_ready_column` and `check_backlog_count` (internal decision points)
* Replace `parse_ready_items` (bool) with `count_ready_items` (usize) to enable a human-readable status message
* Print "Ready column: empty" or "Ready column: N item(s)" during CheckReady instead of raw JSON
* Other phases (GenerateTickets, SizePrioritize, MoveToReady, ImplementTicket) still stream output as before

## Acceptance Criteria

- [x] CheckReady phase no longer dumps raw JSON to the terminal
- [x] A brief, human-readable status message is printed during CheckReady (e.g., "Ready column: empty" or "Ready column: 3 item(s)")
- [x] Other phases (GenerateTickets, SizePrioritize, MoveToReady, ImplementTicket) still stream their output as before
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)