### PR TITLE
#19: Show ticket number and summary in ImplementTicket banner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -318,6 +318,58 @@ fn build_implement_ticket_prompt(config: &Config) -> String {
     )
 }
 
+struct TicketInfo {
+    number: u64,
+    title: String,
+}
+
+#[allow(clippy::question_mark)]
+fn parse_top_ready_ticket(json: &str) -> Option<TicketInfo> {
+    let value = match serde_json::from_str::<serde_json::Value>(json) {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+    let items_value = match value.get("items") {
+        Some(v) => v,
+        None => return None,
+    };
+    let items = match items_value.as_array() {
+        Some(arr) => arr,
+        None => return None,
+    };
+    for item in items {
+        let status = match item.get("status") {
+            Some(s) => match s.as_str() {
+                Some(s) => s,
+                None => continue,
+            },
+            None => continue,
+        };
+        if status != "Ready" {
+            continue;
+        }
+        let number = match item.get("content") {
+            Some(content) => match content.get("number") {
+                Some(n) => match n.as_u64() {
+                    Some(n) => n,
+                    None => continue,
+                },
+                None => continue,
+            },
+            None => continue,
+        };
+        let title = match item.get("title") {
+            Some(t) => match t.as_str() {
+                Some(t) => t.to_string(),
+                None => continue,
+            },
+            None => continue,
+        };
+        return Some(TicketInfo { number, title });
+    }
+    None
+}
+
 fn count_backlog_items(json: &str) -> usize {
     match serde_json::from_str::<serde_json::Value>(json) {
         Ok(value) => match value.get("items") {
@@ -408,6 +460,32 @@ fn check_ready_column(config: &Config, extra_env: &HashMap<String, String>) -> (
             (count > 0, count)
         }
         None => (false, 0),
+    }
+}
+
+fn get_top_ready_ticket(
+    config: &Config,
+    extra_env: &HashMap<String, String>,
+) -> Option<TicketInfo> {
+    let project_str = config.project.to_string();
+    let output = spawn_and_capture(
+        "get-top-ready-ticket",
+        "gh",
+        &[
+            "project",
+            "item-list",
+            &project_str,
+            "--owner",
+            &config.owner,
+            "--format",
+            "json",
+        ],
+        extra_env,
+        true,
+    );
+    match output {
+        Some(json) => parse_top_ready_ticket(&json),
+        None => None,
     }
 }
 
@@ -603,10 +681,13 @@ fn spawn_and_capture(
     }
 }
 
-fn print_phase_banner(phase: &Phase, cycle: u32) {
+fn print_phase_banner(phase: &Phase, cycle: u32, ticket: Option<&TicketInfo>) {
     println!("=========================================");
     println!("  Flywheel \u{2014} cycle {cycle}");
-    println!("  Phase: {phase}");
+    match ticket {
+        Some(info) => println!("  Phase: {phase} \u{2014} #{}: {}", info.number, info.title),
+        None => println!("  Phase: {phase}"),
+    }
     println!("=========================================");
 }
 
@@ -654,7 +735,11 @@ fn main() {
     let mut cycle: u32 = 1;
 
     loop {
-        print_phase_banner(&phase, cycle);
+        let ticket_info = match phase {
+            Phase::ImplementTicket => get_top_ready_ticket(&config, &direnv_env),
+            _ => None,
+        };
+        print_phase_banner(&phase, cycle, ticket_info.as_ref());
 
         match run_phase(&phase, &config, &direnv_env) {
             None => {

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -461,6 +461,56 @@ fn count_ready_items_multiple_ready_items() {
     assert_eq!(count_ready_items(json), 2);
 }
 
+// ── parse_top_ready_ticket ──────────────────────────────────────────
+
+#[test]
+fn parse_top_ready_ticket_returns_first_ready_item() {
+    let json = r#"{"items":[
+        {"status":"Backlog","title":"A","content":{"number":1}},
+        {"status":"Ready","title":"First ready","content":{"number":42}},
+        {"status":"Ready","title":"Second ready","content":{"number":43}}
+    ],"totalCount":3}"#;
+    match parse_top_ready_ticket(json) {
+        Some(info) => {
+            assert_eq!(info.number, 42);
+            assert_eq!(info.title, "First ready");
+        }
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn parse_top_ready_ticket_returns_none_when_no_ready_items() {
+    let json = r#"{"items":[
+        {"status":"Backlog","title":"A","content":{"number":1}},
+        {"status":"Done","title":"B","content":{"number":2}}
+    ],"totalCount":2}"#;
+    assert!(parse_top_ready_ticket(json).is_none());
+}
+
+#[test]
+fn parse_top_ready_ticket_returns_none_for_malformed_json() {
+    assert!(parse_top_ready_ticket("not valid json").is_none());
+}
+
+#[test]
+fn parse_top_ready_ticket_returns_none_when_missing_content_number() {
+    let json = r#"{"items":[{"status":"Ready","title":"No number"}],"totalCount":1}"#;
+    assert!(parse_top_ready_ticket(json).is_none());
+}
+
+#[test]
+fn parse_top_ready_ticket_returns_none_when_missing_title() {
+    let json = r#"{"items":[{"status":"Ready","content":{"number":1}}],"totalCount":1}"#;
+    assert!(parse_top_ready_ticket(json).is_none());
+}
+
+#[test]
+fn parse_top_ready_ticket_returns_none_for_empty_items() {
+    let json = r#"{"items":[],"totalCount":0}"#;
+    assert!(parse_top_ready_ticket(json).is_none());
+}
+
 // ── run_phase: CheckReady variant ───────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Resolves #19

## Summary

* Add `TicketInfo` struct, `parse_top_ready_ticket()`, and `get_top_ready_ticket()` to query the project board and extract the first Ready item's number and title
* Extend `print_phase_banner()` to display ticket info when available (e.g., `Phase: Implement Ticket — #42: Add auth`)
* Falls back to the existing banner format if no Ready ticket is found or the query fails
* Other phase banners remain unchanged

## Acceptance Criteria

- [x] ImplementTicket phase banner shows the ticket number and title (e.g., `#42: Add user authentication`)
- [x] If no Ready ticket is found or the query fails, the banner falls back to the current format without crashing
- [x] Other phase banners remain unchanged
- [x] `parse_top_ready_ticket` has unit tests covering: valid Ready item, no Ready items, malformed JSON, missing fields, multiple Ready items
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)