### PR TITLE
#24: Fix cycle counter to increment on every CheckReady

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -793,7 +793,7 @@ fn main() {
                     println!("--- {} complete, moving to {} ---", phase, next);
                 }
 
-                if phase == Phase::CheckReady && next == Phase::GenerateTickets {
+                if phase == Phase::CheckReady {
                     if config.verbose {
                         println!(
                             "=== Cycle {} complete, starting cycle {} ===",


### PR DESCRIPTION
Resolves #24

## Summary

* Remove the extra `next == Phase::GenerateTickets` guard from the cycle-increment condition in the main loop so the counter ticks on every `CheckReady` completion, not only when the Ready column is empty
* This makes `--max-cycles` effective when the Ready column always has items (previously the loop would run forever)

## Acceptance Criteria

- [x] Cycle counter increments every time `CheckReady` completes, regardless of next phase
- [x] `--max-cycles 2` terminates after exactly 2 CheckReady passes when Ready column always has items
- [x] Existing tests pass (`cargo test` — 55/55)
- [x] No new linter warnings (`cargo clippy -- -D warnings`)