### PR TITLE
#26: Fix Ctrl-C handler to restore original terminal settings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,10 @@ use std::sync::{Arc, Mutex};
 /// The stdin-watcher thread reads this to kill the entire process group.
 static CHILD_PID: AtomicU32 = AtomicU32::new(0);
 
+/// Original terminal settings saved by `RawMode::enter()`.
+/// The Ctrl-C handler reads this to restore the true original state.
+static ORIGINAL_TERMIOS: Mutex<Option<libc::termios>> = Mutex::new(None);
+
 /// Save and restore terminal settings so we can use raw mode for Ctrl-C
 /// detection while a subprocess runs.
 struct RawMode {
@@ -30,6 +34,14 @@ impl RawMode {
             raw.c_cc[libc::VTIME] = 0;
             if libc::tcsetattr(0, libc::TCSANOW, &raw) != 0 {
                 return None;
+            }
+            match ORIGINAL_TERMIOS.lock() {
+                Ok(mut guard) => {
+                    *guard = Some(original);
+                }
+                Err(_) => {
+                    eprintln!("Warning: failed to store original termios");
+                }
             }
             Some(RawMode { original })
         }
@@ -761,12 +773,13 @@ fn main() {
                             }
                         }
                         eprintln!("\n=== Interrupted ===");
-                        // Restore terminal before exiting
-                        unsafe {
-                            let mut original: libc::termios = std::mem::zeroed();
-                            libc::tcgetattr(0, &mut original);
-                            original.c_lflag |= libc::ICANON | libc::ECHO | libc::ISIG;
-                            libc::tcsetattr(0, libc::TCSANOW, &original);
+                        // Restore terminal using the true original settings
+                        if let Ok(guard) = ORIGINAL_TERMIOS.lock()
+                            && let Some(ref termios) = *guard
+                        {
+                            unsafe {
+                                libc::tcsetattr(0, libc::TCSANOW, termios);
+                            }
                         }
                         std::process::exit(1);
                     }

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -788,3 +788,47 @@ fn run_phase_generate_tickets_skip_message_contains_threshold() {
         "skip message should embed the configured threshold value"
     );
 }
+
+// ── ORIGINAL_TERMIOS static ─────────────────────────────────────────
+
+#[test]
+fn original_termios_static_is_lockable() {
+    // Verify the static mutex can be locked without panicking
+    match ORIGINAL_TERMIOS.lock() {
+        Ok(guard) => {
+            let _ = guard.is_some();
+        }
+        Err(e) => panic!("expected Ok, got Err: {e}"),
+    }
+}
+
+#[test]
+fn raw_mode_enter_stores_original_termios() {
+    // RawMode::enter() may fail in CI (no terminal), so handle gracefully
+    match RawMode::enter() {
+        Some(_raw) => match ORIGINAL_TERMIOS.lock() {
+            Ok(guard) => assert!(
+                guard.is_some(),
+                "ORIGINAL_TERMIOS should be Some after enter()"
+            ),
+            Err(e) => panic!("expected Ok, got Err: {e}"),
+        },
+        None => {
+            // No terminal available (CI), skip assertion
+        }
+    }
+}
+
+#[test]
+fn raw_mode_drop_still_works() {
+    // Verify that drop doesn't panic even after our changes
+    match RawMode::enter() {
+        Some(raw) => {
+            drop(raw);
+            // If we get here, drop didn't panic
+        }
+        None => {
+            // No terminal available (CI), skip
+        }
+    }
+}


### PR DESCRIPTION
Resolves #26

## Summary

* Added a `static ORIGINAL_TERMIOS: Mutex<Option<libc::termios>>` to share the true original terminal settings with the Ctrl-C handler thread
* `RawMode::enter()` now stores the original termios in the static after saving it locally
* Replaced the incorrect `tcgetattr` + flag-OR restoration logic in the Ctrl-C handler with a read from `ORIGINAL_TERMIOS`, ensuring all terminal flags (VMIN, VTIME, etc.) are fully restored
* Normal exit via `RawMode::drop()` continues to work unchanged

## Acceptance Criteria

- [x] Ctrl-C handler uses the original terminal settings saved by `RawMode::enter()`, not a re-read of current state
- [x] Terminal is fully restored after Ctrl-C (echo, canonical mode, signal handling all work)
- [x] Normal exit (max-cycles reached) still restores terminal correctly via `RawMode::drop()`
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)