### PR TITLE
#50: Fix CHILD_PID atomic ordering to prevent stale-PID race

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -872,7 +872,7 @@ fn spawn_and_capture(
 
     // Store child PID so the stdin-watcher can kill the process group
     let child_pid = child.id();
-    CHILD_PID.store(child_pid, Ordering::Relaxed);
+    CHILD_PID.store(child_pid, Ordering::Release);
 
     // Spawn a watchdog thread that kills the child process group after the
     // configured timeout.  The flag is set to true once the child exits
@@ -987,7 +987,7 @@ fn spawn_and_capture(
     let _ = stderr_handle.join();
 
     let status = child.wait();
-    CHILD_PID.store(0, Ordering::Relaxed);
+    CHILD_PID.store(0, Ordering::Release);
     child_done.store(true, Ordering::Relaxed);
 
     let timed_out = match watchdog_handle.join() {
@@ -1082,7 +1082,7 @@ fn main() {
                 Ok(0) => break,
                 Ok(_) => {
                     if buf[0] == 0x03 {
-                        let pid = CHILD_PID.load(Ordering::Relaxed);
+                        let pid = CHILD_PID.load(Ordering::Acquire);
                         if pid != 0 {
                             unsafe {
                                 libc::kill(-(pid as i32), libc::SIGTERM);
@@ -1091,11 +1091,11 @@ fn main() {
                             // gracefully before escalating to SIGKILL.
                             for _ in 0..30 {
                                 std::thread::sleep(std::time::Duration::from_millis(100));
-                                if CHILD_PID.load(Ordering::Relaxed) == 0 {
+                                if CHILD_PID.load(Ordering::Acquire) == 0 {
                                     break;
                                 }
                             }
-                            let pid = CHILD_PID.load(Ordering::Relaxed);
+                            let pid = CHILD_PID.load(Ordering::Acquire);
                             if pid != 0 {
                                 unsafe {
                                     libc::kill(-(pid as i32), libc::SIGKILL);

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1665,10 +1665,29 @@ fn merge_config_custom_timeout() {
 fn child_pid_is_zero_after_spawn_and_capture_completes() {
     spawn_and_capture("pid-test", "echo", &["hi"], &HashMap::new(), true, 60);
     assert_eq!(
-        CHILD_PID.load(Ordering::Relaxed),
+        CHILD_PID.load(Ordering::Acquire),
         0,
         "CHILD_PID should be 0 after spawn_and_capture completes"
     );
+}
+
+// ── CHILD_PID: cross-thread store/load without panic ────────────────
+
+#[test]
+fn child_pid_cross_thread_store_load() {
+    let handle = std::thread::spawn(|| {
+        CHILD_PID.store(12345, Ordering::Release);
+    });
+
+    match handle.join() {
+        Ok(_) => {}
+        Err(e) => panic!("thread panicked: {e:?}"),
+    }
+
+    let value = CHILD_PID.load(Ordering::Acquire);
+    assert_eq!(value, 12345, "CHILD_PID should reflect the value stored from another thread");
+
+    CHILD_PID.store(0, Ordering::Release);
 }
 
 // ── SIGTERM grace period: child responds to SIGTERM ─────────────────
@@ -1711,13 +1730,13 @@ fn sigterm_grace_period_child_exits_before_sigkill_needed() {
 
 #[test]
 fn grace_period_logic_skips_sigkill_when_pid_is_zero() {
-    let saved = CHILD_PID.load(Ordering::Relaxed);
-    CHILD_PID.store(0, Ordering::Relaxed);
+    let saved = CHILD_PID.load(Ordering::Acquire);
+    CHILD_PID.store(0, Ordering::Release);
 
-    let pid = CHILD_PID.load(Ordering::Relaxed);
+    let pid = CHILD_PID.load(Ordering::Acquire);
     let would_send_sigkill = pid != 0;
 
-    CHILD_PID.store(saved, Ordering::Relaxed);
+    CHILD_PID.store(saved, Ordering::Release);
 
     assert!(
         !would_send_sigkill,
@@ -1727,13 +1746,13 @@ fn grace_period_logic_skips_sigkill_when_pid_is_zero() {
 
 #[test]
 fn grace_period_logic_sends_sigkill_when_pid_is_nonzero() {
-    let saved = CHILD_PID.load(Ordering::Relaxed);
-    CHILD_PID.store(99999, Ordering::Relaxed);
+    let saved = CHILD_PID.load(Ordering::Acquire);
+    CHILD_PID.store(99999, Ordering::Release);
 
-    let pid = CHILD_PID.load(Ordering::Relaxed);
+    let pid = CHILD_PID.load(Ordering::Acquire);
     let would_send_sigkill = pid != 0;
 
-    CHILD_PID.store(saved, Ordering::Relaxed);
+    CHILD_PID.store(saved, Ordering::Release);
 
     assert!(
         would_send_sigkill,


### PR DESCRIPTION
Resolves #50

## Summary

* Changed all `CHILD_PID.store()` calls from `Ordering::Relaxed` to `Ordering::Release`
* Changed all `CHILD_PID.load()` calls from `Ordering::Relaxed` to `Ordering::Acquire`
* Updated existing test assertions to use matching Acquire/Release ordering
* Added cross-thread store/load test for `CHILD_PID`

## Acceptance Criteria

- [x] All `CHILD_PID.store()` calls use `Ordering::Release`
- [x] All `CHILD_PID.load()` calls use `Ordering::Acquire`
- [x] No `Ordering::Relaxed` remains for `CHILD_PID` operations
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)