### PR TITLE
#160: Sort Ready items by priority before picking next task

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,15 @@ struct TicketInfo {
     title: String,
 }
 
+fn priority_rank(priority: Option<&str>) -> u8 {
+    match priority {
+        Some("P0") => 0,
+        Some("P1") => 1,
+        Some("P2") => 2,
+        _ => 3,
+    }
+}
+
 #[allow(clippy::question_mark)]
 fn parse_top_ready_ticket(json: &str) -> Option<TicketInfo> {
     let value = match serde_json::from_str::<serde_json::Value>(json) {
@@ -429,6 +438,7 @@ fn parse_top_ready_ticket(json: &str) -> Option<TicketInfo> {
         Some(arr) => arr,
         None => return None,
     };
+    let mut ready_items: Vec<(u8, u64, String)> = Vec::new();
     for item in items {
         let status = match item.get("status") {
             Some(s) => match s.as_str() {
@@ -457,9 +467,17 @@ fn parse_top_ready_ticket(json: &str) -> Option<TicketInfo> {
             },
             None => continue,
         };
-        return Some(TicketInfo { number, title });
+        let priority = match item.get("priority") {
+            Some(p) => p.as_str(),
+            None => None,
+        };
+        ready_items.push((priority_rank(priority), number, title));
     }
-    None
+    ready_items.sort_by_key(|item| item.0);
+    ready_items
+        .into_iter()
+        .next()
+        .map(|(_, number, title)| TicketInfo { number, title })
 }
 
 fn count_backlog_items(json: &str) -> usize {

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -744,16 +744,47 @@ fn count_ready_items_multiple_ready_items() {
 // ── parse_top_ready_ticket ──────────────────────────────────────────
 
 #[test]
-fn parse_top_ready_ticket_returns_first_ready_item() {
+fn parse_top_ready_ticket_selects_highest_priority() {
     let json = r#"{"items":[
-        {"status":"Backlog","title":"A","content":{"number":1}},
-        {"status":"Ready","title":"First ready","content":{"number":42}},
-        {"status":"Ready","title":"Second ready","content":{"number":43}}
-    ],"totalCount":3}"#;
+        {"status":"Backlog","title":"A","content":{"number":1},"priority":"P0"},
+        {"status":"Ready","title":"P2 task","content":{"number":42},"priority":"P2"},
+        {"status":"Ready","title":"P0 task","content":{"number":43},"priority":"P0"},
+        {"status":"Ready","title":"P1 task","content":{"number":44},"priority":"P1"}
+    ],"totalCount":4}"#;
     match parse_top_ready_ticket(json) {
         Some(info) => {
-            assert_eq!(info.number, 42);
-            assert_eq!(info.title, "First ready");
+            assert_eq!(info.number, 43);
+            assert_eq!(info.title, "P0 task");
+        }
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn parse_top_ready_ticket_no_priority_treated_as_lowest() {
+    let json = r#"{"items":[
+        {"status":"Ready","title":"No priority","content":{"number":10}},
+        {"status":"Ready","title":"P2 task","content":{"number":11},"priority":"P2"}
+    ],"totalCount":2}"#;
+    match parse_top_ready_ticket(json) {
+        Some(info) => {
+            assert_eq!(info.number, 11);
+            assert_eq!(info.title, "P2 task");
+        }
+        None => panic!("expected Some, got None"),
+    }
+}
+
+#[test]
+fn parse_top_ready_ticket_same_priority_picks_first_in_order() {
+    let json = r#"{"items":[
+        {"status":"Ready","title":"First P1","content":{"number":20},"priority":"P1"},
+        {"status":"Ready","title":"Second P1","content":{"number":21},"priority":"P1"}
+    ],"totalCount":2}"#;
+    match parse_top_ready_ticket(json) {
+        Some(info) => {
+            assert_eq!(info.number, 20);
+            assert_eq!(info.title, "First P1");
         }
         None => panic!("expected Some, got None"),
     }


### PR DESCRIPTION
Resolves #160

## Summary

* Add `priority_rank()` helper that maps P0→0, P1→1, P2→2, missing/unknown→3
* Modify `parse_top_ready_ticket()` to collect all Ready items, sort by priority rank using a stable sort, and return the highest-priority one
* Replace the old single test with three targeted tests covering all acceptance criteria

## Acceptance Criteria

- [x] When multiple Ready items exist with different priorities, P0 is selected over P1, P1 over P2
- [x] Ready items with no priority field are treated as lowest priority (picked last)
- [x] When all Ready items share the same priority, the first in API response order is picked
- [x] Existing tests pass (`cargo test`)
- [x] No new linter warnings (`cargo clippy`)