### PR TITLE
#51: Add SIGTERM/SIGHUP handlers to restore terminal on kill

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,41 @@ impl Drop for RawMode {
     }
 }
 
+/// Async-signal-safe handler that restores the terminal and re-raises the
+/// signal so the process exits with the correct status/code.
+extern "C" fn restore_terminal_and_reraise(sig: libc::c_int) {
+    unsafe {
+        // Read the saved termios.  We cannot use Mutex::lock inside a
+        // signal handler (not async-signal-safe), but try_lock is fine —
+        // if it fails the mutex is held elsewhere and we just skip.
+        if let Ok(guard) = ORIGINAL_TERMIOS.try_lock()
+            && let Some(ref termios) = *guard
+        {
+            libc::tcsetattr(0, libc::TCSANOW, termios);
+        }
+
+        // Reset the signal to its default disposition and re-raise so the
+        // OS records the correct exit status (e.g. 128+signal).
+        libc::signal(sig, libc::SIG_DFL);
+        libc::raise(sig);
+    }
+}
+
+/// Register `restore_terminal_and_reraise` for SIGTERM and SIGHUP using
+/// `sigaction`.  Must be called **after** `RawMode::enter()` so that
+/// `ORIGINAL_TERMIOS` is populated.
+fn register_signal_handlers() {
+    unsafe {
+        let mut sa: libc::sigaction = std::mem::zeroed();
+        sa.sa_sigaction = restore_terminal_and_reraise as *const () as usize;
+        libc::sigemptyset(&mut sa.sa_mask);
+        sa.sa_flags = 0;
+
+        libc::sigaction(libc::SIGTERM, &sa, std::ptr::null_mut());
+        libc::sigaction(libc::SIGHUP, &sa, std::ptr::null_mut());
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 enum Phase {
     GenerateTickets,
@@ -1124,6 +1159,7 @@ fn main() {
     resolve_claude_profile(&mut direnv_env);
 
     let _raw_mode = RawMode::enter();
+    register_signal_handlers();
 
     // Spawn a stdin-watcher thread that reads for Ctrl-C bytes.
     // When detected, kill the child process group and exit.

--- a/src/main_tests.rs
+++ b/src/main_tests.rs
@@ -1893,3 +1893,53 @@ fn build_implement_ticket_prompt_with_ticket_and_base_branch() {
         "prompt should contain --base-branch flag"
     );
 }
+
+// ── signal handler registration ──────────────────────────────────────
+
+#[test]
+fn register_signal_handlers_installs_sigterm_handler() {
+    // After calling register_signal_handlers, the SIGTERM disposition
+    // should no longer be the default (SIG_DFL = 0).
+    register_signal_handlers();
+
+    unsafe {
+        let mut old_sa: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut old_sa);
+        assert_ne!(
+            old_sa.sa_sigaction,
+            libc::SIG_DFL,
+            "SIGTERM handler should not be SIG_DFL after registration"
+        );
+    }
+}
+
+#[test]
+fn register_signal_handlers_installs_sighup_handler() {
+    register_signal_handlers();
+
+    unsafe {
+        let mut old_sa: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGHUP, std::ptr::null(), &mut old_sa);
+        assert_ne!(
+            old_sa.sa_sigaction,
+            libc::SIG_DFL,
+            "SIGHUP handler should not be SIG_DFL after registration"
+        );
+    }
+}
+
+#[test]
+fn restore_terminal_and_reraise_reads_original_termios() {
+    // Verify that the handler function pointer matches what we registered.
+    register_signal_handlers();
+
+    unsafe {
+        let mut old_sa: libc::sigaction = std::mem::zeroed();
+        libc::sigaction(libc::SIGTERM, std::ptr::null(), &mut old_sa);
+        assert_eq!(
+            old_sa.sa_sigaction,
+            restore_terminal_and_reraise as *const () as usize,
+            "SIGTERM handler should point to restore_terminal_and_reraise"
+        );
+    }
+}


### PR DESCRIPTION
* Add restore_terminal_and_reraise signal handler that reads ORIGINAL_TERMIOS and calls tcsetattr before re-raising the signal
* Add register_signal_handlers() using libc::sigaction for SIGTERM and SIGHUP
* Call register_signal_handlers() in main() after RawMode::enter()
* Add tests verifying handler registration for both signals